### PR TITLE
fix: upgrade node-forge to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12224,12 +12224,12 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     ]
   },
   "overrides": {
-    "shell-quote": "$shell-quote"
+    "shell-quote": "$shell-quote",
+    "node-forge": "1.4.0"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Adds npm override for `node-forge` to version 1.4.0
- Resolves 13 Dependabot security alerts: #14, #15, #16, #51, #52, #53, #54, #75, #76, #77, #79, #80, #81
- Fixes: signature forgery (RSA-PKCS, Ed25519), DoS via infinite loop, certificate chain verification bypass, prototype pollution, open redirect, URL parsing issues, ASN.1 vulnerabilities

## Test plan
- [x] `npm install` succeeds
- [x] `react-scripts build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)