### PR TITLE
fix: override @babel/runtime to 7.26.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2082,13 +2082,22 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.0.tgz",
-      "integrity": "sha512-cTIudHnzuWLS56ik4DnRnqqNf8MkdUzV4iFFI1h7Jo9xvrpQROYaAnaSd2mHLQAzzZAPfATynX5ord6YlNYNMA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "license": "MIT",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "overrides": {
     "shell-quote": "$shell-quote",
-    "node-forge": "1.4.0"
+    "node-forge": "1.4.0",
+    "@babel/runtime": "7.26.10"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides @babel/runtime to 7.26.10 to fix ReDoS vulnerability
- Resolves Dependabot alert #100

## Test plan
- [x] npm install succeeds
- [x] react-scripts build passes