### PR TITLE
fix: override loader-utils to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14193,15 +14193,6 @@
         "browserslist": "cli.js"
       }
     },
-    "node_modules/react-dev-utils/node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/react-dev-utils/node_modules/globby": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
@@ -14248,32 +14239,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/react-dev-utils/node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "micromatch": "4.0.8",
     "braces": "3.0.3",
     "semver": "6.3.1",
-    "tough-cookie": "4.1.3"
+    "tough-cookie": "4.1.3",
+    "loader-utils": "1.4.2"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides loader-utils to 1.4.2 to fix ReDoS and prototype pollution
- Resolves Dependabot alerts #85, #86, #87

## Test plan
- [x] Build passes