### PR TITLE
fix: override terser to 4.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16618,17 +16618,17 @@
       }
     },
     "node_modules/terser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "commander": "^2.19.0",
+        "commander": "^2.20.0",
         "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
+        "source-map-support": "~0.5.12"
       },
       "bin": {
-        "terser": "bin/uglifyjs"
+        "terser": "bin/terser"
       },
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "semver": "6.3.1",
     "tough-cookie": "4.1.3",
     "loader-utils": "1.4.2",
-    "minimatch": "3.1.4"
+    "minimatch": "3.1.4",
+    "terser": "4.8.1"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides terser to 4.8.1 to fix ReDoS vulnerability
- Resolves Dependabot alert #83

## Test plan
- [x] Build passes