### PR TITLE
fix: override sockjs to 0.3.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15804,13 +15804,14 @@
       }
     },
     "node_modules/sockjs": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
-      "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
+      "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
       "license": "MIT",
       "dependencies": {
-        "faye-websocket": "^0.10.0",
-        "uuid": "^3.0.1"
+        "faye-websocket": "^0.11.3",
+        "uuid": "^8.3.2",
+        "websocket-driver": "^0.7.4"
       }
     },
     "node_modules/sockjs-client": {
@@ -15827,16 +15828,14 @@
         "url-parse": "^1.4.3"
       }
     },
-    "node_modules/sockjs/node_modules/faye-websocket": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-      "integrity": "sha512-Xhj93RXbMSq8urNCUq4p9l0P6hnySJ/7YNRhYNug0bLOuii7pKO7xQFb5mx9xZXWCar88pLPb805PvUkwrLZpQ==",
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
-      "dependencies": {
-        "websocket-driver": ">=0.5.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/source-list-map": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "loader-utils": "1.4.2",
     "minimatch": "3.1.4",
     "terser": "4.8.1",
-    "nth-check": "2.0.1"
+    "nth-check": "2.0.1",
+    "sockjs": "0.3.24"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides sockjs to 0.3.24 to fix improper input validation
- Resolves Dependabot alert #72

## Test plan
- [x] Build passes