### PR TITLE
fix: override yargs-parser to 13.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17898,15 +17898,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/webpack-dev-server/node_modules/cliui": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
@@ -18084,15 +18075,6 @@
         "which-module": "^2.0.0",
         "y18n": "^3.2.1 || ^4.0.0",
         "yargs-parser": "^10.1.0"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^4.1.0"
       }
     },
     "node_modules/webpack-log": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "minimatch": "3.1.4",
     "terser": "4.8.1",
     "nth-check": "2.0.1",
-    "sockjs": "0.3.24"
+    "sockjs": "0.3.24",
+    "yargs-parser": "13.1.2"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides yargs-parser to 13.1.2 to fix prototype pollution
- Resolves Dependabot alert #69

## Test plan
- [x] Build passes