### PR TITLE
fix: override serialize-javascript to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15411,10 +15411,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
-      "license": "BSD-3-Clause"
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
     },
     "node_modules/serve-index": {
       "version": "1.9.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "terser": "4.8.1",
     "nth-check": "2.0.1",
     "sockjs": "0.3.24",
-    "yargs-parser": "13.1.2"
+    "yargs-parser": "13.1.2",
+    "serialize-javascript": "6.0.2"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides serialize-javascript to 6.0.2 to fix RCE and XSS vulnerabilities
- Resolves Dependabot alerts #40, #67, #68

## Test plan
- [x] Build passes