### PR TITLE
fix: override tmp to 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12138,15 +12138,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -16831,15 +16822,12 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "nth-check": "2.0.1",
     "sockjs": "0.3.24",
     "yargs-parser": "13.1.2",
-    "serialize-javascript": "6.0.2"
+    "serialize-javascript": "6.0.2",
+    "tmp": "0.2.6"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides tmp to 0.2.6 to fix path traversal and symlink vulnerabilities
- Resolves Dependabot alerts #8, #65

## Test plan
- [x] Build passes