### PR TITLE
fix: override flatted to 3.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7756,9 +7756,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/flatten": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "sockjs": "0.3.24",
     "yargs-parser": "13.1.2",
     "serialize-javascript": "6.0.2",
-    "tmp": "0.2.6"
+    "tmp": "0.2.6",
+    "flatted": "3.4.2"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides flatted to 3.4.2 to fix prototype pollution and unbounded recursion DoS
- Resolves Dependabot alerts #43, #44

## Test plan
- [x] Build passes