### PR TITLE
fix: override qs to 6.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14053,12 +14053,18 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/querystring-es3": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "yargs-parser": "13.1.2",
     "serialize-javascript": "6.0.2",
     "tmp": "0.2.6",
-    "flatted": "3.4.2"
+    "flatted": "3.4.2",
+    "qs": "6.14.1"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides qs to 6.14.1 to fix arrayLimit bypass DoS vulnerability
- Resolves Dependabot alert #17

## Test plan
- [x] Build passes