### PR TITLE
fix: upgrade serialize-javascript override to 7.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15409,12 +15409,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "nth-check": "2.0.1",
     "sockjs": "0.3.24",
     "yargs-parser": "13.1.2",
-    "serialize-javascript": "6.0.2",
+    "serialize-javascript": "7.0.5",
     "tmp": "0.2.6",
     "flatted": "3.4.2",
     "qs": "6.15.2",


### PR DESCRIPTION
## Summary
- Upgrades serialize-javascript override to 7.0.5 to fix RCE vulnerability
- Resolves Dependabot alerts #40, #102

## Test plan
- [x] Build passes