### PR TITLE
fix: override ansi-html to 0.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3209,9 +3209,9 @@
       }
     },
     "node_modules/ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha512-JoAxEa1DfP9m2xfB/y2r/aKcwXNlltr4+0QSBC4TrLfcxyvepX2Pv0t/xpgGV5bGsDzCYV8SzjWgyCW0T9yYbA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.8.tgz",
+      "integrity": "sha512-QROYz1I1Kj+8bTYgx0IlMBpRSCIU+7GjbE0oH+KF7QKc+qSF8YAlIutN59Db17tXN70Ono9upT9Ht0iG93W7ug==",
       "engines": [
         "node >= 0.8.0"
       ],

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "tmp": "0.2.6",
     "flatted": "3.4.2",
     "qs": "6.15.2",
-    "form-data": "2.5.4"
+    "form-data": "2.5.4",
+    "ansi-html": "0.0.8"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides ansi-html to 0.0.8 to fix uncontrolled resource consumption
- Resolves Dependabot alert #78

## Test plan
- [x] Build passes