### PR TITLE
fix: override immer to 9.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9071,9 +9071,9 @@
       "license": "ISC"
     },
     "node_modules/immer": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "got": "11.8.5",
     "node-notifier": "8.0.1",
     "uuid": "11.1.1",
-    "react-dev-utils": "11.0.4"
+    "react-dev-utils": "11.0.4",
+    "immer": "9.0.6"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides immer to 9.0.6 to fix prototype pollution vulnerability
- Resolves Dependabot alerts #106, #107

## Test plan
- [x] Build passes