### PR TITLE
fix: upgrade http-proxy-middleware override to 2.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8930,9 +8930,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "qs": "6.15.2",
     "form-data": "2.5.4",
     "ansi-html": "0.0.8",
-    "http-proxy-middleware": "2.0.7",
+    "http-proxy-middleware": "2.0.9",
     "webpack-dev-middleware": "5.3.4",
     "got": "11.8.5",
     "node-notifier": "8.0.1",


### PR DESCRIPTION
## Summary
- Upgrades http-proxy-middleware override to 2.0.9 for additional security fixes
- Resolves Dependabot alerts #104, #105

## Test plan
- [x] Build passes