### PR TITLE
fix: override @tootallnate/once to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4011,12 +4011,12 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "immer": "9.0.6",
     "postcss": "8.5.15",
     "browserslist": "4.28.2",
-    "webpack-dev-server": "5.2.4"
+    "webpack-dev-server": "5.2.4",
+    "@tootallnate/once": "2.0.1"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides @tootallnate/once to 2.0.1
- Resolves Dependabot alert #109

## Test plan
- [x] Build passes