### PR TITLE
fix: override underscore to 1.13.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19415,9 +19415,9 @@
       "license": "MIT"
     },
     "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "postcss": "8.5.15",
     "browserslist": "4.28.2",
     "webpack-dev-server": "5.2.4",
-    "@tootallnate/once": "2.0.1"
+    "@tootallnate/once": "2.0.1",
+    "underscore": "1.13.8"
   },
   "devDependencies": {
     "shell-quote": "^1.8.4"


### PR DESCRIPTION
## Summary
- Overrides underscore to 1.13.8
- Resolves Dependabot alert #108

## Test plan
- [x] Build passes